### PR TITLE
Reduce spacing on checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 [JIRA CARD LINK]
 
 - [ ] Self review
-
 - [ ] I have considered the [Procedure: Considering Security as a PR Submitter](https://www.notion.so/estimateone/Procedure-Considering-Security-as-a-PR-submitter-1409a22d309a8002b037e1ce3f5fd896) and followed the steps outlined.
 
 ## Why?


### PR DESCRIPTION
## Why?

In a PR description, it renders far wider than usual markdown :melting_face: 